### PR TITLE
Deprecated config in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ home_page = https://share.streamlit.io/okld/streamlit-gallery/main?p=pandas-prof
 url = https://github.com/okld/streamlit-pandas-profiling
 author = okld
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 
 [options]
 packages = find:


### PR DESCRIPTION
The license_file parameter is deprecated, use license_files instead